### PR TITLE
Correction des URLs GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/feraudet/la-rache.com.git"
+    "url": "https://github.com/la-rache/la-rache.com.git"
   },
   "keywords": [
     "la-rache"
@@ -23,6 +23,6 @@
   "author": "Cyril Feraudet",
   "license": "WTFPL",
   "bugs": {
-    "url": "https://github.com/feraudet/la-rache.com/issues"
+    "url": "https://github.com/la-rache/la-rache.com/issues"
   }
 }


### PR DESCRIPTION
Il y avait visiblement deux anciennes URLs dans le package.json, corrigées par ce commit.
À noter que GitHub fait néanmoins une redirection vers la nouvelle quand on utilise l'ancienne.
