### PR TITLE
Suppression de liens morts

### DIFF
--- a/src/index10.html
+++ b/src/index10.html
@@ -44,9 +44,9 @@
         <p><a href="http://www.kasskooye.com/">kasskooye.com</a> :
         LA start-up.<br /></p>
 
-        <p><a href="http://tulklut.berlios.de/"><br /></a></p>
+        <!--<p><a href="http://tulklut.berlios.de/"><br /></a></p>
 
         <p><a href="http://tulklut.berlios.de/">tulklut</a> : Un
         logiciel développé à La RACHE parfaitement inutile et
-        totalement indispensable !</p><br />
+        totalement indispensable !</p><br />-->
 {{FOOTER}}

--- a/src/index10.html
+++ b/src/index10.html
@@ -22,12 +22,6 @@
 
         <p><br /></p>
 
-        <p><a href="http://kadreg.org/ipot/">IP Over Time</a> : le
-        protocole de l'avenir, dans tous les sens du
-        terme.<br /></p>
-
-        <p><br /></p>
-
         <p><a href="http://gpp.niacland.net/index.html">GOTO++</a>
         : Un langage de programmation particulièrement adapté à La
         RACHE.<br /></p>
@@ -43,10 +37,4 @@
 
         <p><a href="http://www.kasskooye.com/">kasskooye.com</a> :
         LA start-up.<br /></p>
-
-        <!--<p><a href="http://tulklut.berlios.de/"><br /></a></p>
-
-        <p><a href="http://tulklut.berlios.de/">tulklut</a> : Un
-        logiciel développé à La RACHE parfaitement inutile et
-        totalement indispensable !</p><br />-->
 {{FOOTER}}


### PR DESCRIPTION
Les sites http://tulklut.berlios.de et http://kadreg.org sont mort et enterrés...
J'ai viré les liens.