### PR TITLE
Liens morts.

### DIFF
--- a/src/liens.html
+++ b/src/liens.html
@@ -15,14 +15,6 @@
         <p><br /></p>
 
         <p><a href=
-        "http://www.bernardbelanger.com/computing/NaDa/">NaDa</a> :
-        Le logiciel indispensable par excellence, il s'adapte
-        particulièrement bien dans un environnement géré à La
-        RACHE.<br /></p>
-
-        <p><br /></p>
-
-        <p><a href=
         "http://perso.duckcorp.org/duck/mirrors/kadreg.free.fr/ipot/">
         IP Over Time</a> :
         Le protocole de l'avenir, dans tous les sens du

--- a/src/liens.html
+++ b/src/liens.html
@@ -22,7 +22,7 @@
 
         <p><br /></p>
 
-        <p><a href="http://gpp.niacland.net/index.html">GOTO++</a>
+<p><a href="https://esolangs.org/wiki/GOTO%2B%2B">GOTO++ (site en Anglais)</a>
         : Un langage de programmation particulièrement adapté à La
         RACHE.<br /></p>
 


### PR DESCRIPTION
**_[Résout le problème #18]_**

Sur la page des [liens](https://www.la-rache.com/liens.html), il y avait quelques liens morts : 
- Le [NaDa](http://www.bernardbelanger.com/computing/NaDa/) : Erreur _404 Not Found_.
  - Remplacé par une [page wiki (en anglais)](https://esolangs.org/wiki/GOTO%2B%2B)
- Le [GOTO++](http://gpp.niacland.net/index.html) : Adresse introuvable.

