### PR TITLE
Correction d'une erreur critique empêchant toute compréhension possible

### DIFF
--- a/src/publications.html
+++ b/src/publications.html
@@ -29,7 +29,7 @@
         référence.<br />
         <br />
         Remarque : Patrick DUBOIS D'ENGHIEN nous signale qu'une
-        erreur malencontreuse s'est glissée dans ce document La
+        erreur malencontreuse s'est glissée dans ce document. La
         chiée exprime une valeur non pifométrique mais au contraire
         précise et internationalement reconnue : Une chiée vaut 11.
         Et oui, c'est bien connu : 11 fait chiée.<br />


### PR DESCRIPTION
de la phrase expliquant l'unité de la chiée.