### PR TITLE
Gitignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Include your project-specific ignores in this file
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
 node_modules
+package-lock.json
 *.swp
 build


### PR DESCRIPTION
Verrouiller explicitement les versions des dépendances représente une
démarche qualité incompatible avec la méthodologie la-rache™.

Il serait tout à fait regrettable qu'un débutant commite
accidentellement son fichier de lock, et que celui-ci franchisse le mur
de la review de code. (par accident, cela va de soi)